### PR TITLE
Document HallJoy v1.4.0 publication

### DIFF
--- a/docs/v1.4/README.md
+++ b/docs/v1.4/README.md
@@ -17,7 +17,8 @@ version or release status.
 - Production diagnostics: no continuous telemetry or log writer; crash-only
   `HallJoyCrash.txt`
 - Public release notes: [`RELEASE_NOTES_v1.4.md`](../../RELEASE_NOTES_v1.4.md)
-- GitHub publication: prepared locally, commit/push/release pending
+- GitHub publication: [`v1.4.0`](https://github.com/PashOK7/HallJoy/releases/tag/v1.4.0)
+  published as the latest stable release
 - Final artifact: `build/release/HallJoy.exe`, 2,187,776 bytes, SHA-256
   `C03CB7A19DB73921D69904A7ABDAB954D54F3D5CE42899ADD9C24012D93D0402`
 

--- a/docs/v1.4/ROADMAP.md
+++ b/docs/v1.4/ROADMAP.md
@@ -907,6 +907,7 @@ v1.4 can be tagged only when:
 - Current clean artifact: `build/release/HallJoy.exe`, 2,187,776 bytes,
   SHA-256
   `C03CB7A19DB73921D69904A7ABDAB954D54F3D5CE42899ADD9C24012D93D0402`.
-- Remaining publication work is Git-only: review the complete integration diff,
-  commit it intentionally, push/merge it to `main`, create tag `v1.4.0`, and
-  publish the clean four-file release package.
+- Publication completed through PR
+  [#3](https://github.com/PashOK7/HallJoy/pull/3), merge commit
+  `b63b3b209bf0cbf1736810e5d04489568e6cb79c`, annotated tag `v1.4.0`, and the
+  [latest stable GitHub Release](https://github.com/PashOK7/HallJoy/releases/tag/v1.4.0).

--- a/docs/v1.4/VALIDATION_MATRIX.md
+++ b/docs/v1.4/VALIDATION_MATRIX.md
@@ -2623,3 +2623,18 @@ stock firmware remains unsupported for gaming**.
 - `version_identity_static_audit.py`: PASS;
 - `protocol_family_routing_static_audit.py`: PASS;
 - complete `run_native_backend_checks.py --require-compiler`: PASS.
+
+### GitHub publication
+
+- release integration commit: `723eb6a10ee1d9814df9d5e158d599a9ce439f3c`;
+- PR `#3` into `main`: MERGED after two portable and two Windows Release jobs
+  passed;
+- merge commit: `b63b3b209bf0cbf1736810e5d04489568e6cb79c`;
+- annotated tag `v1.4.0`: resolves to the merge commit, PASS;
+- GitHub Release `v1.4.0`: published, non-draft, non-prerelease, and returned by
+  the latest-release API, PASS;
+- uploaded assets: `HallJoy.exe`, `README_FOR_TESTER.txt`, `SHA256SUMS.txt`, and
+  `THIRD_PARTY_NOTICES.md`, all in `uploaded` state, PASS;
+- GitHub asset digest for `HallJoy.exe`:
+  `sha256:c03cb7a19db73921d69904a7abdab954d54f3d5ce42899add9c24012d93d0402`,
+  matching the locally qualified release artifact, PASS.

--- a/docs/v1.4/WORKLOG.md
+++ b/docs/v1.4/WORKLOG.md
@@ -2998,3 +2998,25 @@ Production startup/shutdown smoke passed without a continuous or crash log.
 The release directory was rebuilt after smoke so it contains only the intended
 four files. Final EXE: 2,187,776 bytes, SHA-256
 `C03CB7A19DB73921D69904A7ABDAB954D54F3D5CE42899ADD9C24012D93D0402`.
+
+## 2026-08-10: GitHub v1.4.0 publication
+
+Backed up the complete working tree outside the repository together with a Git
+bundle of every reachable ref. Audited all 64 untracked files before staging;
+no executable, DLL, object, log, firmware, archive, credential, build, or backup
+path entered the 189-file release commit. Staged whitespace and forbidden-path
+checks passed.
+
+Published integration commit `723eb6a10ee1d9814df9d5e158d599a9ce439f3c`
+to `v1.4-integration` and opened PR
+[#3](https://github.com/PashOK7/HallJoy/pull/3). Both push and PR workflow runs
+passed their portable and Windows Release jobs. The PR was merged normally into
+`main` as `b63b3b209bf0cbf1736810e5d04489568e6cb79c`; no force push or check bypass
+was used.
+
+Created annotated tag `v1.4.0` on that merge commit and published
+[HallJoy v1.4.0](https://github.com/PashOK7/HallJoy/releases/tag/v1.4.0) as the
+latest stable, non-draft, non-prerelease GitHub Release. Uploaded the four clean
+package files. GitHub reports the EXE asset at 2,187,776 bytes with digest
+`sha256:c03cb7a19db73921d69904a7abdab954d54f3d5ce42899add9c24012d93d0402`,
+matching the qualified local file and `SHA256SUMS.txt`.


### PR DESCRIPTION
﻿## What changed

Records the completed v1.4.0 GitHub publication in the authoritative roadmap, validation matrix, worklog, and current-status index.

## Why

The release commit necessarily described commit/push/tag/release as pending. This follow-up keeps the live `main` documentation truthful after publication without moving the immutable release tag or changing the qualified binary.

## Validation

- `s20_build_docs_static_audit.py`: PASS
- `version_identity_static_audit.py`: PASS
- `git diff --check`: PASS
- release/tag/assets verified through GitHub API
