### PR TITLE
Docs: record streamlined v1.4 release

### DIFF
--- a/docs/v1.4/VALIDATION_MATRIX.md
+++ b/docs/v1.4/VALIDATION_MATRIX.md
@@ -2633,8 +2633,11 @@ stock firmware remains unsupported for gaming**.
 - annotated tag `v1.4.0`: resolves to the merge commit, PASS;
 - GitHub Release `v1.4.0`: published, non-draft, non-prerelease, and returned by
   the latest-release API, PASS;
-- uploaded assets: `HallJoy.exe`, `README_FOR_TESTER.txt`, `SHA256SUMS.txt`, and
+- public assets: `HallJoy.exe`, `SHA256SUMS.txt`, and
   `THIRD_PARTY_NOTICES.md`, all in `uploaded` state, PASS;
+- the test-only `README_FOR_TESTER.txt` is intentionally excluded from the
+  public release; the release page links directly to `HallJoy.exe` before a
+  collapsed full changelog, PASS;
 - GitHub asset digest for `HallJoy.exe`:
   `sha256:c03cb7a19db73921d69904a7abdab954d54f3d5ce42899add9c24012d93d0402`,
   matching the locally qualified release artifact, PASS.

--- a/docs/v1.4/WORKLOG.md
+++ b/docs/v1.4/WORKLOG.md
@@ -3016,7 +3016,15 @@ was used.
 
 Created annotated tag `v1.4.0` on that merge commit and published
 [HallJoy v1.4.0](https://github.com/PashOK7/HallJoy/releases/tag/v1.4.0) as the
-latest stable, non-draft, non-prerelease GitHub Release. Uploaded the four clean
-package files. GitHub reports the EXE asset at 2,187,776 bytes with digest
+latest stable, non-draft, non-prerelease GitHub Release. The initial upload used
+the four clean package files. GitHub reports the EXE asset at 2,187,776 bytes
+with digest
 `sha256:c03cb7a19db73921d69904a7abdab954d54f3d5ce42899add9c24012d93d0402`,
 matching the qualified local file and `SHA256SUMS.txt`.
+
+After publication, shortened the visible release summary and moved the complete
+release notes into a collapsed `<details>` section. Added a direct
+`HallJoy.exe` download link at the top so users do not need to scroll through
+the changelog. Removed the test-only `README_FOR_TESTER.txt` public asset; the
+release now exposes only `HallJoy.exe`, `SHA256SUMS.txt`, and
+`THIRD_PARTY_NOTICES.md`. The executable and its digest were not changed.


### PR DESCRIPTION
## Summary

- record the streamlined v1.4.0 GitHub Release page
- document the direct HallJoy.exe link and collapsed full changelog
- record removal of the test-only README_FOR_TESTER.txt public asset

## Validation

- S20 build/documentation static audit passed
- staged diff check passed
- live release API confirms three intended assets and the unchanged EXE digest